### PR TITLE
Disable order_id input text on return_form.tpl

### DIFF
--- a/upload/catalog/view/theme/default/template/account/return_form.tpl
+++ b/upload/catalog/view/theme/default/template/account/return_form.tpl
@@ -61,7 +61,7 @@
           <div class="form-group required">
             <label class="col-sm-2 control-label" for="input-order-id"><?php echo $entry_order_id; ?></label>
             <div class="col-sm-10">
-              <input type="text" name="order_id" value="<?php echo $order_id; ?>" placeholder="<?php echo $entry_order_id; ?>" id="input-order-id" class="form-control" />
+              <input type="text" name="order_id" value="<?php echo $order_id; ?>" placeholder="<?php echo $entry_order_id; ?>" id="input-order-id" class="form-control" disabled />
               <?php if ($error_order_id) { ?>
               <div class="text-danger"><?php echo $error_order_id; ?></div>
               <?php } ?>


### PR DESCRIPTION
Leaving it enabled makes it possible for users/customers to change the order id when submitting return for an order, which has a fixed order id.